### PR TITLE
Set correct player sprite direction when pikachu is diving

### DIFF
--- a/src/resources/js/view.js
+++ b/src/resources/js/view.js
@@ -457,9 +457,19 @@ export class GameView {
 
     this.player1.x = player1.x;
     this.player1.y = player1.y;
+    if (player1.state === 3 || player1.state === 4) {
+      this.player1.scale.x = player1.divingDirection === -1 ? -1 : 1;
+    } else {
+      this.player1.scale.x = 1;
+    }
     this.shadows.forPlayer1.x = player1.x;
     this.player2.x = player2.x;
     this.player2.y = player2.y;
+    if (player2.state === 3 || player2.state === 4) {
+      this.player2.scale.x = player2.divingDirection === 1 ? 1 : -1;
+    } else {
+      this.player2.scale.x = -1;
+    }
     this.shadows.forPlayer2.x = player2.x;
 
     const frameNumber1 = getFrameNumberForPlayerAnimatedSprite(


### PR DESCRIPTION
Pikachu always looks at the other side, but when it divings, it have to look in the direction of diving.
